### PR TITLE
Feature/burn gas fee

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -45,6 +45,11 @@ var (
 	addressT = reflect.TypeOf(Address{})
 )
 
+var (
+	// BurnGasAddr is gas burning address which would never roll back.
+	BurnGasAddr = HexToAddress("0x000000000000000000000000000000000000dEaD")
+)
+
 // Hash represents the 32 byte Keccak256 hash of arbitrary data.
 type Hash [HashLength]byte
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -29,6 +29,7 @@ import (
 )
 
 var (
+	// Use this address as gas fee burning address, which would not be transferred back again.
 	SystemAddress = common.HexToAddress("0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE")
 )
 
@@ -145,4 +146,5 @@ type PoSA interface {
 	EnoughDistance(chain ChainReader, header *types.Header) bool
 	IsLocalBlock(header *types.Header) bool
 	AllowLightProcess(chain ChainReader, currentHeader *types.Header) bool
+	BurnGasFee(state *state.StateDB) *big.Int
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1082,18 +1082,7 @@ func (p *Parlia) distributeIncoming(
 
 	log.Trace("burn the gas fee", "block hash", header.Hash(), "amount", balance)
 
-	// reward zero amount
-	var rewards = big.NewInt(0)
-
-	err := p.distributeToSystem(rewards, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
-	if err != nil {
-		return err
-	}
-
-	log.Trace("distribute to system reward pool and validator contract",
-		"block hash", header.Hash(), "amount", rewards)
-
-	return p.distributeToValidator(balance, val, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
+	return nil
 }
 
 // slash spoiled validators
@@ -1147,35 +1136,6 @@ func (p *Parlia) initContract(state *state.StateDB, header *types.Header, chain 
 		}
 	}
 	return nil
-}
-
-func (p *Parlia) distributeToSystem(amount *big.Int, state *state.StateDB, header *types.Header, chain core.ChainContext,
-	txs *[]*types.Transaction, receipts *[]*types.Receipt, receivedTxs *[]*types.Transaction, usedGas *uint64, mining bool) error {
-	// get system message
-	msg := p.getSystemMessage(header.Coinbase, common.HexToAddress(systemcontract.SystemRewardContract), nil, amount)
-	// apply message
-	return p.applyTransaction(msg, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
-}
-
-// slash spoiled validators
-func (p *Parlia) distributeToValidator(amount *big.Int, validator common.Address,
-	state *state.StateDB, header *types.Header, chain core.ChainContext,
-	txs *[]*types.Transaction, receipts *[]*types.Receipt, receivedTxs *[]*types.Transaction, usedGas *uint64, mining bool) error {
-	// method
-	method := "deposit"
-
-	// get packed data
-	data, err := p.validatorSetABI.Pack(method,
-		validator,
-	)
-	if err != nil {
-		log.Error("Unable to pack tx for deposit", "error", err)
-		return err
-	}
-	// get system message
-	msg := p.getSystemMessage(header.Coinbase, common.HexToAddress(systemcontract.ValidatorContract), data, amount)
-	// apply message
-	return p.applyTransaction(msg, state, header, chain, txs, receipts, receivedTxs, usedGas, mining)
 }
 
 // get system message

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -278,6 +278,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// consensus engine is parlia
 	if st.evm.ChainConfig().Parlia != nil {
+		// cache the reward to system address
 		st.state.AddBalance(consensus.SystemAddress, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))
 	} else {
 		st.state.AddBalance(st.evm.Context.Coinbase, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.gasPrice))

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -196,11 +196,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 		vmenv := vm.NewEVM(context, txContext, statedb, eth.blockchain.Config(), vm.Config{})
 		if posa, ok := eth.Engine().(consensus.PoSA); ok && msg.From() == context.Coinbase &&
 			posa.IsSystemContract(msg.To()) && msg.GasPrice().Cmp(big.NewInt(0)) == 0 {
-			balance := statedb.GetBalance(consensus.SystemAddress)
-			if balance.Cmp(common.Big0) > 0 {
-				statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-				statedb.AddBalance(context.Coinbase, balance)
-			}
+			posa.BurnGasFee(statedb)
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), idx)
 		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -535,11 +535,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
-				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(vmctx.Coinbase, balance)
-				}
+				posa.BurnGasFee(statedb)
 			}
 		}
 
@@ -643,11 +639,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
-				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(block.Header().Coinbase, balance)
-				}
+				posa.BurnGasFee(statedb)
 			}
 		}
 
@@ -767,11 +759,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		if posa, ok := api.backend.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
-				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(vmctx.Coinbase, balance)
-				}
+				posa.BurnGasFee(statedb)
 			}
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
@@ -933,11 +921,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 
 	if posa, ok := api.backend.Engine().(consensus.PoSA); ok && message.From() == vmctx.Coinbase &&
 		posa.IsSystemContract(message.To()) && message.GasPrice().Cmp(big.NewInt(0)) == 0 {
-		balance := statedb.GetBalance(consensus.SystemAddress)
-		if balance.Cmp(common.Big0) > 0 {
-			statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-			statedb.AddBalance(vmctx.Coinbase, balance)
-		}
+		posa.BurnGasFee(statedb)
 	}
 
 	// Call Prepare to clear out the statedb access list

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1228,11 +1228,7 @@ func (s *PublicBlockChainAPI) replay(ctx context.Context, block *types.Block, ac
 
 		if posa, ok := s.b.Engine().(consensus.PoSA); ok {
 			if isSystem, _ := posa.IsSystemTransaction(tx, block.Header()); isSystem {
-				balance := statedb.GetBalance(consensus.SystemAddress)
-				if balance.Cmp(common.Big0) > 0 {
-					statedb.SetBalance(consensus.SystemAddress, big.NewInt(0))
-					statedb.AddBalance(block.Header().Coinbase, balance)
-				}
+				posa.BurnGasFee(statedb)
 			}
 		}
 


### PR DESCRIPTION
### Description

The PR would burn the validator gas fee to `0xdead` address, whose amount would not be claimed.

### Rationale

We aim to deflate the local concurrency.

### Example

```
curl -X POST -H 'Content-Type: application/json' http://localhost:18545 -d '{
    "id": 0,
    "jsonrpc": "2.0",
    "method": "eth_getBalance",
    "params": ["0x000000000000000000000000000000000000dEaD","latest"]
}'
```

After sending transactions, we'll see that fees go exactly to the `0xdead` address.

### Changes

Notable changes: 
* No more validator reward from staking.
* No more system reward.
