### PR TITLE
Upstream patch: fix memory leak issue with diff protocol

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -390,6 +390,7 @@ func (h *handler) runDiffExtension(peer *diff.Peer, handler diff.Handler) error 
 
 	if err := h.peers.registerDiffExtension(peer); err != nil {
 		peer.Log().Error("Diff extension registration failed", "err", err)
+		peer.Close()
 		return err
 	}
 	return handler(peer)

--- a/eth/handler_diff.go
+++ b/eth/handler_diff.go
@@ -45,6 +45,7 @@ func (h *diffHandler) RunPeer(peer *diff.Peer, hand diff.Handler) error {
 			wait <- peer
 		}
 		ps.lock.Unlock()
+		peer.Close()
 		return err
 	}
 	return (*handler)(h).runDiffExtension(peer, hand)


### PR DESCRIPTION
### Description

#### From: [#1019](https://github.com/bnb-chain/bsc/pull/1019)

broadcastDiffLayers is not properly closed, the memory accumulates too many resources and causes OOM.

```
goroutine 8845520 [select, 3426 minutes]:
github.com/ethereum/go-ethereum/eth/protocols/diff.(*Peer).broadcastDiffLayers(0xc081628d20)
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:47 +0xab
created by github.com/ethereum/go-ethereum/eth/protocols/diff.NewPeer
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:41 +0x2f0

goroutine 7119763 [select, 3531 minutes]:
github.com/ethereum/go-ethereum/eth/protocols/diff.(*Peer).broadcastDiffLayers(0xc10bcd4e40)
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:47 +0xab
created by github.com/ethereum/go-ethereum/eth/protocols/diff.NewPeer
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:41 +0x2f0

goroutine 11443031 [select, 3272 minutes]:
github.com/ethereum/go-ethereum/eth/protocols/diff.(*Peer).broadcastDiffLayers(0xc0f9bb3260)
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:47 +0xab
created by github.com/ethereum/go-ethereum/eth/protocols/diff.NewPeer
	github.com/ethereum/go-ethereum/eth/protocols/diff/peer.go:41 +0x2f0
```

### Rationale

`broadcastDiffLayers` will be started in `NewPeer`; need to call `peer.Close` when `RunPeer` fails. otherwise, this goroutine will not be closed.

### Example

[panic.log](https://github.com/bnb-chain/bsc/files/9187772/panic.log)

### Changes

 Notable changes:

    close the peer on failure in RunPeer function.
