### PR TITLE
Upstream patch: defer bloomprocessor close

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -403,6 +403,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	for i, tx := range block.Transactions() {
 		if isPoSA {
 			if isSystemTx, err := posa.IsSystemTransaction(tx, block.Header()); err != nil {
+				bloomProcessors.Close()
 				return statedb, nil, nil, 0, err
 			} else if isSystemTx {
 				systemTxs = append(systemTxs, tx)
@@ -412,11 +413,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 
 		msg, err := tx.AsMessage(signer)
 		if err != nil {
+			bloomProcessors.Close()
 			return statedb, nil, nil, 0, err
 		}
 		statedb.Prepare(tx.Hash(), block.Hash(), i)
 		receipt, err := applyTransaction(msg, p.config, p.bc, nil, gp, statedb, header, tx, usedGas, vmenv, bloomProcessors)
 		if err != nil {
+			bloomProcessors.Close()
 			return statedb, nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 


### PR DESCRIPTION
### Description

#### From: [#860](https://github.com/bnb-chain/bsc/pull/860)

There's risk of memory leak for channel in bloomProcessors in Process when an early return happen.
Rationale

We need to ensure closing channel (bloomProcessors.Close()) before return

### Changes

Notable changes:

    user defer to make sure bloomProcessors.Close() be executed before Process return
    keep current bloomProcessors.Close() for efficiency.



