### PR TITLE
Remove failed contract create transaction

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -570,6 +570,9 @@ func (evm *EVM) CanCreateContract(caller ContractRef) bool {
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	if !evm.CanCreateContract(caller) {
+		nonce := evm.StateDB.GetNonce(caller.Address())
+		evm.StateDB.SetNonce(caller.Address(), nonce+1) // should update its nonce even failed
+
 		return nil, common.Address{}, 0, ErrContractCreatorNotAuthorized
 	}
 

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -570,7 +570,7 @@ func (evm *EVM) CanCreateContract(caller ContractRef) bool {
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 	if !evm.CanCreateContract(caller) {
-		return nil, contractAddr, leftOverGas, ErrContractCreatorNotAuthorized
+		return nil, common.Address{}, 0, ErrContractCreatorNotAuthorized
 	}
 
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))


### PR DESCRIPTION
### Description

The not authorized contract creation transaction not removed from mempool.

This PR fixes it.